### PR TITLE
HYCOM Updates: Cache and Retry for network hiccups & Forecast Mode

### DIFF
--- a/examples/HYCOM/gen_bnd.py
+++ b/examples/HYCOM/gen_bnd.py
@@ -3,7 +3,7 @@ import logging
 import argparse
 
 from pyschism.mesh.hgrid import Hgrid
-from pyschism.forcing.hycom.hycom2schism import OpenBoundaryInventory
+from pyschism.forcing.hycom.hycom2schism import OpenBoundaryInventory, get_raw_hycom
 '''
 outputs:
     elev2D.th.nc (elev=True)
@@ -71,7 +71,20 @@ if __name__ == "__main__":
         action='store_true',
         default=True,
         help='Generate velocity boundary conditions (default: True)')
-
+    parser.add_argument(
+        '--forecast-mode',
+        action='store_true',
+        default=False,
+        help='Generate boundary conditions from forecast mode (default: False)'
+    )
+    parser.add_argument('--archive-data',
+                        action='store_true',
+                        default=False,
+                        help='Archive data (default: False)')
+    parser.add_argument('--timeout-seconds',
+                        type=int,
+                        default=15,
+                        help='Timeout in seconds (default: 15)')
     args = parser.parse_args()
 
     hgrid = Hgrid.open(args.hgrid, crs='epsg:4326')
@@ -83,7 +96,10 @@ if __name__ == "__main__":
                        elev2D=args.elev2d,
                        TS=args.ts,
                        UV=args.uv,
-                       ocean_bnd_ids=args.ocean_bnd_ids)
+                       ocean_bnd_ids=args.ocean_bnd_ids,
+                       forecast_mode=bool(args.forecast_mode),
+                       archive_data=bool(args.archive_data),
+                       timeout_seconds=args.timeout_seconds)
     except Exception as e:
         logger.error(f'Error fetching data: {e}')
         raise e

--- a/examples/HYCOM/gen_bnd.py
+++ b/examples/HYCOM/gen_bnd.py
@@ -85,6 +85,14 @@ if __name__ == "__main__":
                         type=int,
                         default=15,
                         help='Timeout in seconds (default: 15)')
+    parser.add_argument('--forecast_length_hours',
+                        type=int,
+                        default=15,
+                        help='forecast_length_hours')
+    parser.add_argument('--forecast_freq_hours',
+                        type=int,
+                        default=15,
+                        help='forecast_freq_hours')
     args = parser.parse_args()
 
     hgrid = Hgrid.open(args.hgrid, crs='epsg:4326')
@@ -99,7 +107,9 @@ if __name__ == "__main__":
                        ocean_bnd_ids=args.ocean_bnd_ids,
                        forecast_mode=bool(args.forecast_mode),
                        archive_data=bool(args.archive_data),
-                       timeout_seconds=args.timeout_seconds)
+                       timeout_seconds=args.timeout_seconds,
+                       forecast_length_hours=args.forecast_length_hours,
+                       forecast_freq_hours=args.forecast_freq_hours)
     except Exception as e:
         logger.error(f'Error fetching data: {e}')
         raise e

--- a/examples/HYCOM/gen_bnd.py
+++ b/examples/HYCOM/gen_bnd.py
@@ -76,11 +76,14 @@ if __name__ == "__main__":
 
     hgrid = Hgrid.open(args.hgrid, crs='epsg:4326')
     bnd = OpenBoundaryInventory(hgrid, args.vgrid)
-
-    bnd.fetch_data(args.outdir,
-                   args.start_date,
-                   args.rnday,
-                   elev2D=args.elev2d,
-                   TS=args.ts,
-                   UV=args.uv,
-                   ocean_bnd_ids=args.ocean_bnd_ids)
+    try:
+        bnd.fetch_data(args.outdir,
+                       args.start_date,
+                       args.rnday,
+                       elev2D=args.elev2d,
+                       TS=args.ts,
+                       UV=args.uv,
+                       ocean_bnd_ids=args.ocean_bnd_ids)
+    except Exception as e:
+        logger.error(f'Error fetching data: {e}')
+        raise e

--- a/pyschism/forcing/hycom/hycom2schism.py
+++ b/pyschism/forcing/hycom/hycom2schism.py
@@ -8,7 +8,7 @@ import subprocess
 import shutil
 from typing import Union, Optional
 from time import time
-
+import traceback
 import numpy as np
 import scipy as sp
 import requests
@@ -80,29 +80,136 @@ def get_database(date, Bbox=None):
         database = f'GLBv0.08/expt_53.X/data/{date.year}'
     else:
         raise ValueError(f'No data fro {date}!')
-    logger.info(f'Using HYCOM database: {database}')
+    logger.debug(f'Using HYCOM database: {database}')
     return database
+
+
+def get_base_url(date: datetime):
+
+    database = get_database(date)
+    if database.startswith('ESPC-D'):
+        base_url = f'https://tds.hycom.org/thredds/dodsC/FMRC_{database}/runs/FMRS_{database}_RUN_{date.strftime("%Y-%m-%dT12:00:00Z")}?'
+        # base_url = f'https://tds.hycom.org/thredds/dodsC/datasets/{database}/data/archive/{date.year}/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_{date.strftime("%Y%m%dT12")}_t0000_{var}.nc?'
+    else:
+        if date >= datetime.now(timezone.utc).replace(tzinfo=None):
+            date2 = datetime.now(
+                timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+            base_url = f'https://tds.hycom.org/thredds/dodsC/{database}/FMRC/runs/GLBy0.08_930_FMRC_RUN_{date2.strftime("%Y-%m-%dT12:00:00Z")}?'
+        else:
+            base_url = f'https://tds.hycom.org/thredds/dodsC/{database}?'
+    return base_url
+
+
+def get_raw_hycom(date: datetime,
+                  bbox: Bbox,
+                  write_to_file: bool = False,
+                  source: str = 'archive'):
+    '''
+    Works for 'archive' and 'forecast' data sources which are non-aggregated.
+
+    This process handles the non-aggregated data avalable fro mthe tds.ycom.org/thredds/dodsC source.
+
+
+    vars = ["Sssh", "s3z", "ice", "t3z", "u3z", "v3z", "ssh"]
+    vars_of_interest = ['s3z', 't3z', 'u3z', 'v3z']
+    for var in vars:
+        url = f'https://tds.hycom.org/thredds/dodsC/datasets/ESPC-D-V02/data/archive/2025/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_2025072912_t0000_{var}.nc'
+        ds = Dataset(url)
+        print(var)
+        print(ds.dimensions)
+        dss = BoundaryDataset(url)
+    # "https://tds.hycom.org/thredds/catalog/datasets/ESPC-D-V02/data/archive/catalog.html"
+    # "https://tds.hycom.org/thredds/dodsC/datasets/ESPC-D-V02/data/archive/2025/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_2025072912_t0000_Sssh.nc"
+    
+    '''
+    database = 'ESPC-D-V02'
+    vars_of_interest = ['s3z', 't3z', 'u3z', 'v3z', 'ssh']
+    # vars_of_interest = ['ssh']
+    # bbox = Bbox(xmin=bbox.xmin, xmax=bbox.xmax, ymin=bbox.ymin, ymax=bbox.ymax)
+    # 3 hours per chunk to ensure all data vars are included. Some vars are saved at 1 hour intervals.
+    # TODO: allow subsetting of these time chunks.
+    if source == 'forecast':
+        time_chunks = [f'{x:04d}' for x in np.arange(0, 192, 3)]
+    elif source == 'archive':
+        time_chunks = [f'{x:04d}' for x in np.arange(0, 24, 3)]
+    else:
+        raise ValueError(f'Invalid source: {source}')
+    combined = []
+    for var in vars_of_interest:
+        dss = []
+        for time_chunk in time_chunks:
+            # forecast: only has last ten dayts but has longer time series
+            # base_url = f'https://tds.hycom.org/thredds/dodsC/datasets/{database}/data/archive/{date.year}/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008__{date.strftime("%Y%m%d12")}_t{time_chunk}_{var}.nc'  # + DIMENSIONS
+            if source == 'forecast':
+                base_url = f'https://tds.hycom.org/thredds/dodsC/datasets/{database}/data/forecasts/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_{date.strftime("%Y%m%d12")}_t{time_chunk}_{var}.nc'
+            elif source == 'archive':
+                base_url = f'https://tds.hycom.org/thredds/dodsC/datasets/{database}/data/archive/{date.year}/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_{date.strftime("%Y%m%d12")}_t{time_chunk}_{var}.nc'
+            # archive
+            # base_url = f'https://tds.hycom.org/thredds/dodsC/datasets/{database}/data/archive/{date.year}/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_{date.strftime("%Y%m%d12")}_t{time_chunk}_{var}.nc'  # + DIMENSIONS
+            # base_url = f'https://tds.hycom.org/thredds/dodsC/datasets/ESPC-D-V02/data/archive/{date.year}/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_2025072612_t0000_Sssh.nc'
+            # TODO: paralellize this portion... pass a url and return an xarray dataset via the netcdf4 dataset.
+            xrds = xr.open_dataset(base_url,
+                                   decode_times=False,
+                                   chunks={
+                                       'lat': 100,
+                                       'lon': 100
+                                   }).sel(lon=slice(bbox.xmin, bbox.xmax),
+                                          lat=slice(bbox.ymin, bbox.ymax))
+            dss.append(xrds)
+        combined.append(
+            xr.combine_nested(dss, 'time', combine_attrs='override'))
+    subset = xr.merge(combined, combine_attrs='override')
+    if write_to_file:
+        subset.to_netcdf(f'hycom_archive_{date.strftime("%Y%m%d")}.nc')
+    return subset
+
+
+def decode_nc_times(nc_time_array):
+    return nc.num2date(nc_time_array,
+                       units=nc_time_array.units,
+                       only_use_cftime_datetimes=False)
 
 
 def get_idxs(date: datetime,
              database: str,
              bbox: Bbox,
              lonc: Optional[float] = None,
-             latc: Optional[float] = None):
-
-    if date >= datetime.utcnow():
-        date2 = datetime.utcnow() - timedelta(days=1)
-        baseurl = f'https://tds.hycom.org/thredds/dodsC/{database}/FMRC/runs/GLBy0.08_930_FMRC_RUN_{date2.strftime("%Y-%m-%dT12:00:00Z")}?depth[0:1:-1],lat[0:1:-1],lon[0:1:-1],time[0:1:-1]'
+             latc: Optional[float] = None,
+             archive_data: bool = False,
+             forecast_mode: bool = False,
+             url_date: str = None):
+    '''
+    Args:
+    date: datetime object which time to lookup in the dataset
+    database: str
+    bbox: Bbox object
+    lonc: Optional[float]
+    latc: Optional[float]
+    archive_data: bool
+    forecast_mode: bool are we extracting all dates from the same forecast (i.e., same base_url)?
+    url_date: datetime if forecast_mode is True we use this date to fetch the dataset from which date will be extracted. (If forecast_mode is False, url_date = date)
+    
+    Returns:
+    time_idx: int
+    lon_idx1: int
+    lon_idx2: int
+    lat_idx1: int
+    '''
+    logger.info(f'Getting idxs for {date}')
+    if not forecast_mode:
+        url_date = date
     else:
-        baseurl = f'https://tds.hycom.org/thredds/dodsC/FMRC_{database}/runs/FMRS_{database}_RUN_{date.strftime("%Y-%m-%dT12:00:00Z")}?depth[0:1:-1],lat[0:1:-1],lon[0:1:-1],time[0:1:-1]' if database.startswith(
-            'ESPC-D'
-        ) else f'https://tds.hycom.org/thredds/dodsC/{database}?lat[0:1:-1],lon[0:1:-1],time[0:1:-1],depth[0:1:-1]'
-        # baseurl = f'https://tds.hycom.org/thredds/dodsC/{database}/runs/FMRC_ESPC-D-V02_all_RUN_{date.strftime("%Y-%m-%dT12:00:00Z")}?depth[0:1:-1],lat[0:1:-1],lon[0:1:-1],time[0:1:-1]'
-    ds = Dataset(baseurl)
+        assert url_date is not None, 'url_date is required for forecast_mode'
+    DIMENSIONS = 'lat[0:1:-1],lon[0:1:-1],time[0:1:-1],depth[0:1:-1]'
+    baseurl = get_base_url(url_date) + DIMENSIONS
+    ds = BoundaryDataset(baseurl,
+                         xrds=archive_data,
+                         archive_data=archive_data,
+                         date=url_date,
+                         bbox=bbox)
     time1 = ds['time']
-    times = nc.num2date(time1,
-                        units=time1.units,
-                        only_use_cftime_datetimes=False)
+    times = decode_nc_times(time1)
+    logger.info(f'times in ds from date {url_date}: {times}')
 
     lon = ds['lon'][:]
     lat = ds['lat'][:]
@@ -116,12 +223,19 @@ def get_idxs(date: datetime,
             logger.info(
                 f'Convert HYCOM longitude from [0, 360) to [-180, 180):')
             idxs = lon >= 180
-            lon[idxs] = lon[idxs] - 360
+            #  ds.ds['lon'] = (ds.ds['lon'] + 180) % 360 - 180
+            if archive_data:
+                lon.values[idxs] = lon[idxs] - 360
+            else:
+                lon[idxs] = lon[idxs] - 360
         elif lon.min() <= 0:
             logger.info(
                 f'Convert HYCOM longitude from [-180, 180) to [0, 360):')
             idxs = lon <= 0
-            lon[idxs] = lon[idxs] + 360
+            if archive_data:
+                lon.values[idxs] = lon[idxs] + 360
+            else:
+                lon[idxs] = lon[idxs] + 360
 
     lat_idxs = np.where((lat >= bbox.ymin - 0.5) & (lat <= bbox.ymax + 0.5))[0]
     lon_idxs = np.where((lon >= bbox.xmin - 0.5) & (lon <= bbox.xmax + 0.5))[0]
@@ -160,6 +274,7 @@ def get_idxs(date: datetime,
     if len(idxs) == 0:
         logger.info(f'No date for date {date}')
         sys.exit()
+
     time_idx = idxs.item()
 
     ds.close()
@@ -168,8 +283,21 @@ def get_idxs(date: datetime,
 
 
 def transform_ll_to_cpp(lon, lat, lonc=-77.07, latc=24.0):
+    '''
+    Transforms longitude and latitude values to the CPP coordinate system. A local projection.
+    Args:
+
+    lon: 1D array of longitude values
+        lat: 1D array of latitude values
+        lonc: central longitude
+        latc: central latitude
+    Returns:
+        lon_new: 1D array of transformed longitude values
+        lat_new: 1D array of transformed latitude values
+    '''
     longitude = lon / 180 * np.pi
     latitude = lat / 180 * np.pi
+    # earth radius in meters
     radius = 6378206.4
     loncc = lonc / 180 * np.pi
     latcc = latc / 180 * np.pi
@@ -210,7 +338,7 @@ def interp_to_points_3d(dep, y2, x2, bxyz, val):
     return val_int
 
 
-def interp_to_points_2d(y2, x2, bxy, val):
+def interp_to_points_2d(y2, x2, bxy, val, archive_data: bool = False):
     idxs = np.where(abs(val) > 10000)
     val[idxs] = float('nan')
 
@@ -220,7 +348,6 @@ def interp_to_points_2d(y2, x2, bxy, val):
         idxs = np.argsort(x2)
         x2 = x2[idxs]
         val = val[:, idxs]
-
     val_fd = sp.interpolate.RegularGridInterpolator((y2, x2),
                                                     np.squeeze(val),
                                                     'linear',
@@ -254,23 +381,45 @@ class BoundaryDataset:
 
     _timeout = 15  # seconds
 
-    def __init__(self, url):
+    def __init__(self,
+                 url,
+                 xrds: bool = False,
+                 archive_data: bool = False,
+                 date: datetime = None,
+                 bbox: Bbox = None):
         '''Wraps netcdf4.Dataset to add a cache and retries.
         '''
         # super().__init__(url)
         self._cache = {}
         self.url = url
-        # self._ds = Dataset(url)
+        self.xrds = xrds
+        self.archive_data = archive_data
+        self.date = date
+        self.bbox = bbox
 
     @property
     def ds(self):
         if not hasattr(self, '_ds'):
-            self._ds = self.open_ds(self.url)
+            if self.archive_data:
+                self._ds = get_raw_hycom(self.date, self.bbox)
+            else:
+                # Works for 'archive' and self.open_ds sources which are non-aggregated.
+                self._ds = self.open_ds(
+                    self.url) if not self.xrds else self.open_xrds(self.url)
         return self._ds
 
     @staticmethod
     def open_ds(url: str):
         return Dataset(url)
+
+    @staticmethod
+    def open_xrds(url: str):
+        return xr.open_dataset(url,
+                               decode_times=False,
+                               chunks={
+                                   'lat': 100,
+                                   'lon': 100
+                               })
 
     def close(self):
         '''We dont want to clear the cache bc it is associated with this instance and this instance itself is cached.'''
@@ -302,7 +451,10 @@ class OpenBoundaryInventory:
                    restart=False,
                    adjust2D=False,
                    lats=None,
-                   msl_shifts=None):
+                   msl_shifts=None,
+                   forecast_mode: bool = False,
+                   archive_data: bool = False,
+                   timeout_seconds: int = 15):
         '''
         Fetch data from HYCOM and save to netcdf files.
         Args:
@@ -311,17 +463,26 @@ class OpenBoundaryInventory:
             rnday: number of days
             ocean_bnd_ids: open boundary ids
             elev2D: whether to save 2D elevation data
-        
+            forecast_mode: means we use a single Dataset for all the available timesteps instead of updating the url for each timestep. in production forecasts we would use this because we are extracting from the latest available forceast.
+            archive_data: means we are using the thredds 'archive' data, which is available from 2024 to present but is packaged as a .nc file per 3-hr timestep, so is transformed differently. uses xarray instead of netcdf4.Dataset.
         TODO:
           - Add a local cache for the data to work around finicky HYCOM server.
+          - Replace netcdf4.Dataset with xarray.Dataset for aggregated data (i.e., when archive_data is False)
         '''
         outdir = pathlib.Path(outdir)
 
         self.start_date = start_date
         self.rnday = rnday
-        self.timevector = np.arange(
-            self.start_date, self.start_date + timedelta(days=self.rnday + 1),
-            timedelta(days=1)).astype(datetime)
+        if forecast_mode:
+            self.start_date = self.start_date.replace(hour=12)
+            self.timevector = np.arange(
+                self.start_date, self.start_date + timedelta(days=self.rnday),
+                timedelta(hours=12)).astype(datetime)
+        else:
+            self.timevector = np.arange(
+                self.start_date,
+                self.start_date + timedelta(days=self.rnday + 1),
+                timedelta(days=1)).astype(datetime)
 
         #Get open boundary
         gdf = self.hgrid.boundaries.open.copy()
@@ -361,7 +522,7 @@ class OpenBoundaryInventory:
             #y2i=np.tile(yi,[nvrt,1]).T
             #bxyz=np.c_[zcor2.reshape(np.size(zcor2)),y2i.reshape(np.size(y2i)),x2i.reshape(np.size(x2i))]
             #logger.info('Computing SCHISM zcor is done!')
-
+        logger.info(f'Creating netcdf files in {outdir}')
         #create netcdf
         ntimes = self.rnday + 1
         nComp1 = 1
@@ -477,12 +638,13 @@ class OpenBoundaryInventory:
             timevector = self.timevector[time_idx_restart - 1:]
             it0 = time_idx_restart - 1
 
-        for it1, date in enumerate(timevector):
-
+        for it1, ds_date in enumerate(timevector):
             it = it0 + it1
 
-            database = get_database(date)
-            logger.info(f'Fetching data for {date} from database {database}')
+            database = get_database(
+                timevector[0] if forecast_mode else ds_date)
+            logger.info(
+                f'Fetching data for {ds_date} from database {database}')
 
             #loop over each open boundary
             ind1 = 0
@@ -499,6 +661,7 @@ class OpenBoundaryInventory:
                 blonc = blon.mean()
                 blatc = blat.mean()
                 #logger.info(f'blonc = {blon.mean()}, blatc = {blat.mean()}')
+                # this is some spoooky stuff. But we're transforing to a local projection.
                 xi, yi = transform_ll_to_cpp(blon, blat, blonc, blatc)
                 bxy = np.c_[yi, xi]
 
@@ -519,62 +682,55 @@ class OpenBoundaryInventory:
                 bbox = Bbox.from_extents(xmin, ymin, xmax, ymax)
 
                 time_idx, lon_idx1, lon_idx2, lat_idx1, lat_idx2, x2, y2, _ = get_idxs(
-                    date, database, bbox, lonc=blonc, latc=blatc)
+                    ds_date,
+                    database,
+                    bbox,
+                    lonc=blonc,
+                    latc=blatc,
+                    archive_data=archive_data,
+                    forecast_mode=forecast_mode,
+                    url_date=timevector[0] if forecast_mode else ds_date)
 
                 url_data_subsets = f'surf_el[{time_idx}][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}],' + \
                         f'water_temp[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}],' + \
                         f'salinity[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}],' + \
                         f'water_u[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}],' + \
                         f'water_v[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}]'
-                # vars = ["Sssh", "s3z", "ice", "t3z", "u3z", "v3z", "ssh"]
-                # for var in vars:
-                #     url = f'https://tds.hycom.org/thredds/dodsC/datasets/ESPC-D-V02/data/archive/2025/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_2025072912_t0000_{var}.nc'
-                #     ds = Dataset(url)
-                #     print(ds)
-                #     dss = BoundaryDataset(url)
-                #     breakpoint()
-                # "https://tds.hycom.org/thredds/catalog/datasets/ESPC-D-V02/data/archive/catalog.html"
-                # "https://tds.hycom.org/thredds/dodsC/datasets/ESPC-D-V02/data/archive/2025/US058GCOM-OPSnce.espc-d-031-hycom_fcst_glby008_2025072912_t0000_Sssh.nc"
-                if date >= datetime.now(timezone.utc).replace(tzinfo=None):
-                    date2 = datetime.now(
-                        timezone.utc).replace(tzinfo=None) - timedelta(days=1)
-                    # Real time ESPC runs used if database.startswith('ESPC-D') is True; should be used when, e.g. database = 'ESPC-D-V02_all'
-                    url_base = f'https://tds.hycom.org/thredds/dodsC/FMRC_{database}/runs/FMRS_{database}_RUN_' if database.startswith(
-                        'ESPC-D'
-                    ) else f'https://tds.hycom.org/thredds/dodsC/{database}/FMRC/runs/GLBy0.08_930_FMRC_RUN_'
-                    url = url_base + \
-                        f'{date2.strftime("%Y-%m-%dT12:00:00Z")}?depth[0:1:-1],lat[{lat_idx1}:1:{lat_idx2}],' + \
-                        f'lon[{lon_idx1}:1:{lon_idx2}],time[{time_idx}],' + \
-                        url_data_subsets
-
-                else:
-                    url = f'https://tds.hycom.org/thredds/dodsC/FMRC_{database}/runs/FMRC_{database}_RUN_{date.strftime("%Y-%m-%dT12:00:00Z")}?' if database.startswith(
-                        'ESPC-D'
-                    ) else f'https://tds.hycom.org/thredds/dodsC/{database}?'
-                    url = url + f'lat[{lat_idx1}:1:{lat_idx2}],' + \
-                        f'lon[{lon_idx1}:1:{lon_idx2}],depth[0:1:-1],time[{time_idx}],' + \
-                        url_data_subsets
-                #logger.info(url)
-
-                ds = BoundaryDataset(url)
-                logger.debug(
-                    f"fetchingurl {url} \nwith a BoundaryDataset instance with id {id(ds)}"
+                DIMENSIONS = f'depth[0:1:-1],lat[{lat_idx1}:1:{lat_idx2}],lon[{lon_idx1}:1:{lon_idx2}],time[{time_idx}],'
+                logger.info(
+                    f'base url: {get_base_url(timevector[0] if forecast_mode else ds_date)}'
+                )
+                url = get_base_url(timevector[0] if forecast_mode else ds_date
+                                   ) + DIMENSIONS + url_data_subsets
+                # Extract data
+                ds = BoundaryDataset(
+                    url,
+                    xrds=archive_data,
+                    archive_data=archive_data,
+                    date=timevector[0] if forecast_mode else ds_date,
+                    bbox=bbox)
+                logger.warning(
+                    f"fetching url {url} \nwith a BoundaryDataset instance with id {id(ds)}"
                 )
                 dep = ds['depth'][:]
 
                 logger.info(
                     f'****Interpolation starts for boundary {ibnd}****')
-
                 #ndt[it]=it*24*3600.
-                timeout = 10
-                time_limit = time() + timeout
+                time_limit = time() + timeout_seconds
                 while True:
                     try:
                         if elev2D:
                             #ssh
-                            ssh = np.squeeze(ds['surf_el'][:, :])
-
-                            ssh_int = interp_to_points_2d(y2, x2, bxy, ssh)
+                            ssh = np.squeeze(
+                                ds['surf_el'][0, :, :]
+                                if forecast_mode else ds['surf_el'][:, :])
+                            ssh_int = interp_to_points_2d(
+                                y2,
+                                x2,
+                                bxy,
+                                ssh.values if archive_data else ssh,
+                                archive_data=archive_data)
                             dst_elev['time'][it] = it * 24 * 3600.
                             if adjust2D:
                                 elev_adjust = np.interp(blat, lats, msl_shifts)
@@ -584,13 +740,14 @@ class OpenBoundaryInventory:
                             else:
                                 dst_elev['time_series'][it, ind1:ind2, 0,
                                                         0] = ssh_int
-
                         if TS:
                             #salt
-                            salt = np.squeeze(ds['salinity'][:, :, :])
-
+                            salt = np.squeeze(
+                                ds['salinity'][0, :, :, :]
+                                if forecast_mode else ds['salinity'][:, :, :])
                             salt_int = interp_to_points_3d(
-                                dep, y2, x2, bxyz, salt)
+                                dep, y2, x2, bxyz,
+                                salt.values if archive_data else salt)
                             salt_int = salt_int.reshape(zcor2.shape)
                             #timeseries_s[it,:,:,0]=salt_int
                             dst_salt['time'][it] = it * 24 * 3600.
@@ -598,10 +755,15 @@ class OpenBoundaryInventory:
                                                     0] = salt_int
 
                             #temp
-                            temp = np.squeeze(ds['water_temp'][:, :, :])
-
+                            temp = np.squeeze(ds['water_temp'][
+                                0, :, :, :] if forecast_mode else
+                                              ds['water_temp'][:, :, :])
                             #Convert temp to potential temp
-                            ptemp = ConvertTemp(salt, temp, dep)
+                            # needs to be fixed for xarray
+                            ptemp = ConvertTemp(
+                                salt.values if archive_data else salt,
+                                temp.values if archive_data else temp,
+                                dep.values if archive_data else dep)
 
                             temp_int = interp_to_points_3d(
                                 dep, y2, x2, bxyz, ptemp)
@@ -612,20 +774,25 @@ class OpenBoundaryInventory:
                                                     0] = temp_int
 
                         if UV:
-                            uvel = np.squeeze(ds['water_u'][:, :, :])
-                            vvel = np.squeeze(ds['water_v'][:, :, :])
-
+                            uvel = np.squeeze(
+                                ds['water_u'][0, :, :, :]
+                                if forecast_mode else ds['water_u'][:, :, :])
+                            vvel = np.squeeze(
+                                ds['water_v'][0, :, :, :]
+                                if forecast_mode else ds['water_v'][:, :, :])
                             dst_uv['time'][it] = it * 24 * 3600.
                             #uvel
                             uvel_int = interp_to_points_3d(
-                                dep, y2, x2, bxyz, uvel)
+                                dep, y2, x2, bxyz,
+                                uvel.values if archive_data else uvel)
                             uvel_int = uvel_int.reshape(zcor2.shape)
                             dst_uv['time_series'][it, ind1:ind2, :,
                                                   0] = uvel_int
 
                             #vvel
                             vvel_int = interp_to_points_3d(
-                                dep, y2, x2, bxyz, vvel)
+                                dep, y2, x2, bxyz,
+                                vvel.values if archive_data else vvel)
                             vvel_int = vvel_int.reshape(zcor2.shape)
                             dst_uv['time_series'][it, ind1:ind2, :,
                                                   1] = vvel_int
@@ -857,7 +1024,7 @@ class Nudge:
             it = it0 + it1
 
             database = get_database(date)
-            logger.info(f'Fetching data for {date} from database {database}')
+            logger.debug(f'Fetching data for {date} from database {database}')
 
             ind1 = 0
             ind2 = 0
@@ -899,23 +1066,10 @@ class Nudge:
                     logger.info(
                         f'Local copy of HYCOM file {hycom_local_copy} does not exist. Downloading...'
                     )
-                    if date >= datetime.utcnow():
-                        date2 = datetime.utcnow() - timedelta(days=1)
-                        # Real time ESPC runs used if database.startswith('ESPC-D') is True; should be used when, e.g. database = 'ESPC-D-V02_all'
-                        url_base = f'https://tds.hycom.org/thredds/dodsC/FMRC_{database}/runs/FMRS_{database}_RUN_' if database.startswith(
-                            'ESPC-D'
-                        ) else f'https://tds.hycom.org/thredds/dodsC/{database}/FMRC/runs/GLBy0.08_930_FMRC_RUN_'
-                        url = url_base + \
-                            f'{date2.strftime("%Y-%m-%dT12:00:00Z")}?depth[0:1:-1],lat[{lat_idx1}:1:{lat_idx2}],' + \
-                            f'lon[{lon_idx1}:1:{lon_idx2}],time[{time_idx}],' + \
-                            f'water_temp[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}],' + \
-                            f'salinity[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}]'
-
-                    else:
-                        url=f'https://tds.hycom.org/thredds/dodsC/{database}?lat[{lat_idx1}:1:{lat_idx2}],' + \
-                            f'lon[{lon_idx1}:1:{lon_idx2}],depth[0:1:-1],time[{time_idx}],' + \
-                            f'water_temp[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}],' + \
-                            f'salinity[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}]'
+                    DIMENSIONS = f'depth[0:1:-1],lat[{lat_idx1}:1:{lat_idx2}],lon[{lon_idx1}:1:{lon_idx2}],time[{time_idx}],'
+                    url_data_subsets = f'water_temp[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}],' + \
+                        f'salinity[{time_idx}][0:1:39][{lat_idx1}:1:{lat_idx2}][{lon_idx1}:1:{lon_idx2}]'
+                    url = get_base_url(date) + DIMENSIONS + url_data_subsets
                     # Download the data
                     xr.open_dataset(url).to_netcdf(hycom_local_copy)
 
@@ -927,7 +1081,7 @@ class Nudge:
 
                 #Convert temp to potential temp
                 dep = ds['depth'][:]
-                ptemp = ConvertTemp(salt, temp, dep)
+                ptemp = ConvertTemp(salt, temp, dep, xrds=False)
 
                 logger.info('****Interpolation starts****')
 
@@ -1019,7 +1173,7 @@ class DownloadHycom:
                 salt = ds.salinity.values
                 dep = ds.depth.values
 
-                ptemp = ConvertTemp(salt, temp, dep)
+                ptemp = ConvertTemp(salt, temp, dep, xrds=False)
                 #drop water_temp variable and add new temperature variable
                 ds = ds.drop('water_temp')
                 ds['temperature'] = (['time', 'depth', 'lat', 'lon'], ptemp)

--- a/pyschism/forcing/hycom/hycom2schism.py
+++ b/pyschism/forcing/hycom/hycom2schism.py
@@ -742,9 +742,9 @@ class OpenBoundaryInventory:
                     try:
                         if elev2D:
                             #ssh
-                            ssh = np.squeeze(
-                                ds['surf_el'][0, :, :]
-                                if forecast_mode else ds['surf_el'][:, :])
+                            ssh = np.squeeze(ds['surf_el'][
+                                0, :, :] if forecast_mode or archive_data else
+                                             ds['surf_el'][:, :])
                             ssh_int = interp_to_points_2d(
                                 y2,
                                 x2,
@@ -762,9 +762,9 @@ class OpenBoundaryInventory:
                                                         0] = ssh_int
                         if TS:
                             #salt
-                            salt = np.squeeze(
-                                ds['salinity'][0, :, :, :]
-                                if forecast_mode else ds['salinity'][:, :, :])
+                            salt = np.squeeze(ds['salinity'][
+                                0, :, :, :] if forecast_mode or archive_data
+                                              else ds['salinity'][:, :, :])
                             salt_int = interp_to_points_3d(
                                 dep, y2, x2, bxyz,
                                 salt.values if archive_data else salt)
@@ -776,8 +776,8 @@ class OpenBoundaryInventory:
 
                             #temp
                             temp = np.squeeze(ds['water_temp'][
-                                0, :, :, :] if forecast_mode else
-                                              ds['water_temp'][:, :, :])
+                                0, :, :, :] if forecast_mode or archive_data
+                                              else ds['water_temp'][:, :, :])
                             #Convert temp to potential temp
                             # needs to be fixed for xarray
                             ptemp = ConvertTemp(
@@ -794,25 +794,25 @@ class OpenBoundaryInventory:
                                                     0] = temp_int
 
                         if UV:
-                            uvel = np.squeeze(
-                                ds['water_u'][0, :, :, :]
-                                if forecast_mode else ds['water_u'][:, :, :])
-                            vvel = np.squeeze(
-                                ds['water_v'][0, :, :, :]
-                                if forecast_mode else ds['water_v'][:, :, :])
+                            uvel = np.squeeze(ds['water_u'][
+                                0, :, :, :] if forecast_mode or archive_data
+                                              else ds['water_u'][:, :, :])
+                            vvel = np.squeeze(ds['water_v'][
+                                0, :, :, :] if forecast_mode or archive_data
+                                              else ds['water_v'][:, :, :])
                             dst_uv['time'][it] = it * 24 * 3600.
                             #uvel
                             uvel_int = interp_to_points_3d(
-                                dep, y2, x2, bxyz,
-                                uvel.values if archive_data else uvel)
+                                dep, y2, x2, bxyz, uvel.values
+                                if forecast_mode or archive_data else uvel)
                             uvel_int = uvel_int.reshape(zcor2.shape)
                             dst_uv['time_series'][it, ind1:ind2, :,
                                                   0] = uvel_int
 
                             #vvel
                             vvel_int = interp_to_points_3d(
-                                dep, y2, x2, bxyz,
-                                vvel.values if archive_data else vvel)
+                                dep, y2, x2, bxyz, vvel.values
+                                if forecast_mode or archive_data else vvel)
                             vvel_int = vvel_int.reshape(zcor2.shape)
                             dst_uv['time_series'][it, ind1:ind2, :,
                                                   1] = vvel_int


### PR DESCRIPTION
This PR address a few issues and introduces some design modifications along the way. Several chunks of code were pulled off into helper functions.

## Problem 1
- Existing process extracted data from thredds server in a loop. Requests went out when data extractions were performed. If there was a network issue, any incremental success is thrown away.

## Solution 1
- Add some cacheing and some retry behavior
- Introduces a class `BoundaryDataset` as a pseudo-child class of netcdf4.Dataset. This object is cached based on the url used to access a netcdf data object. Any dataset objects access via that specific object are themselves held in a dictionary cache associated with the object. So keeping a session alive with retries, etc., means data that has been accessed remains accessible in memory.
- Some simple retry behavior is added in `OpenBoundaryInventory.fetch_data` to try to armor against network or server issues. The `timeout_seconds` argument configures the timeout.

## Problem 2
The base URL used to access thredds hycom data was updated for each timestamp in a requested range. That means that a different model run was being accessed for each timestamp and subsetted for the first date available in that run. This works for hindcasting because you get the best available input data from each of the archived forecasts to build your boundary data time series. In forecasting, we cannot access different model runs for each date of the boundary conditions request- we only have the most recent model run and we must access all of the dates in the boundary conditions request from that single base url.

## Solution 2
Adds a `forecast_mode` flag which uses the requested `start_date` as the baseurl and extracts each timestamp available in the request range from that single forecast run.

## Problem 3
The etl routine assumes you are accessing one of the aggregated data products. There is no support for accessing archive data, which would allow a wider range of dates to be used.

## Solution 3
Adds an `archive_mode` flag which adds support for the archive data via thredds and adds the associated transormations necessary to aggregate the data from its raw format so that it can be used for SCHISM boundary conditions. This also adds `xarray.Dataset` support, since that makes those transformations a lot easier.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210790841716893