### PR TITLE
GFS routine: allow forecasting 

### DIFF
--- a/examples/Sflux/gen_sflux_from_GFS.py
+++ b/examples/Sflux/gen_sflux_from_GFS.py
@@ -45,6 +45,10 @@ if __name__ == '__main__':
         help=
         'Use temporary directory for generated files (default: True); if the files already exist, pass their path as --pscr and set --use-tempdir to False to avoid re-downloading the files.'
     )
+    parser.add_argument('--forecast-mode',
+                        type=cli_bool,
+                        default=False,
+                        help='Run in forecast mode (default: False)')
 
     args = parser.parse_args()
 
@@ -57,4 +61,5 @@ if __name__ == '__main__':
               air=True,
               prc=True,
               rad=True,
-              use_tempdir=bool(args.use_tempdir))
+              use_tempdir=bool(args.use_tempdir),
+              forecast_mode=bool(args.use_tempdir))

--- a/pyschism/forcing/nws/nws2/gfs2.py
+++ b/pyschism/forcing/nws/nws2/gfs2.py
@@ -213,15 +213,17 @@ class GFS:
               air: bool = True,
               prc: bool = True,
               rad: bool = True,
-              use_tempdir: bool = True):
+              use_tempdir: bool = True,
+              forecast_mode: bool = False):
         start_date = nearest_cycle() if start_date is None else start_date
 
         if (start_date + timedelta(days=rnday)) > datetime.utcnow():
-            logger.info(
-                f'End date is beyond the current time, set rnday to 1 day and record to 5 days'
-            )
-            rnday = 1
-            self.record = 5  #days
+            if not forecast_mode:
+                logger.info(
+                    f'End date is beyond the current time, set rnday to 1 day and record to 5 days'
+                )
+                rnday = 1
+                self.record = 5  #days
 
         end_date = start_date + timedelta(hours=rnday * self.record + 1)
         logger.info(f'start time is {start_date}, end time is {end_date}')


### PR DESCRIPTION
Adds a boolean flag to bypass a switch that resets rnday and self.record for atmospheric data extraction time ranges... that has been kicking in for our operational forecast mode when we actually want to allow looking ahead into the future.

@wjcrawford I think this will solve your issue.